### PR TITLE
Rename ridTransactionService.ajaxMethod() to be more descriptive

### DIFF
--- a/metridoc-grails-rid/grails-app/controllers/metridoc/rid/RidTransactionController.groovy
+++ b/metridoc-grails-rid/grails-app/controllers/metridoc/rid/RidTransactionController.groovy
@@ -34,7 +34,7 @@ class RidTransactionController {
     static boolean isProtected = true
 
     def ajaxChooseType = {
-        def response = ridTransactionService.ajaxMethod(params, session.getAttribute("transType"))
+        def response = ridTransactionService.getFieldsByLibraryUnit(params, session.getAttribute("transType"))
         render response as JSON
     }
 

--- a/metridoc-grails-rid/grails-app/services/metridoc/rid/RidTransactionService.groovy
+++ b/metridoc-grails-rid/grails-app/services/metridoc/rid/RidTransactionService.groovy
@@ -251,7 +251,7 @@ class RidTransactionService {
         }
     }
 
-    def ajaxMethod(Map params, String transType) {
+    def getFieldsByLibraryUnit(Map params, String transType) {
         if (transType == "consultation") {
             def userGoals = RidUserGoal.findAllByRidLibraryUnitAndInForm(RidLibraryUnit.get(params.typeId), 1)
             def consultations = RidModeOfConsultation.findAllByRidLibraryUnitAndInForm(RidLibraryUnit.get(params.typeId), 1)

--- a/metridoc-grails-rid/test/unit/metridoc/rid/RidTransactionControllerTests.groovy
+++ b/metridoc-grails-rid/test/unit/metridoc/rid/RidTransactionControllerTests.groovy
@@ -37,7 +37,7 @@ abstract class RidTransactionControllerTests { //Removes no runnable methods err
     void setUpSessionAndSecurityUtils() {
         serviceMocker = mockFor(RidTransactionService, true)  // mock the service
         serviceMocker.demand.createNewConsInstanceMethod { params, ridTransactionInstance -> }
-        serviceMocker.demand.ajaxMethod { params -> return [book: "Great"] }
+        serviceMocker.demand.getParamsByLibraryUnit { params -> return [book: "Great"] }
         controller.ridTransactionService = serviceMocker.createMock(); // inject it into the controller
         session.setAttribute("transType", "consultation")
         // Mocks the SecurityUtils


### PR DESCRIPTION
I originally intended to refactor it as well, but since there is only one instructional transaction case, I don't mind it as is.
#69
