### PR TITLE
fix spring-test issue

### DIFF
--- a/metridoc-grails-core/grails-app/conf/BuildConfig.groovy
+++ b/metridoc-grails-core/grails-app/conf/BuildConfig.groovy
@@ -75,7 +75,9 @@ grails.project.dependency.resolution = {
 
     plugins {
         runtime ":twitter-bootstrap:2.3.2"
-        runtime ":mail:1.0.1"
+        runtime(":mail:1.0.1") {
+            excludes 'spring-test'
+        }
         runtime ":hibernate:3.6.10.6"
         runtime ":resources:1.1.6"
         runtime ":jquery:1.10.2.2"

--- a/metridoc-grails-illiad/grails-app/conf/BuildConfig.groovy
+++ b/metridoc-grails-illiad/grails-app/conf/BuildConfig.groovy
@@ -77,8 +77,6 @@ grails.project.dependency.resolution = {
 
     dependencies {
         compile 'net.sf.opencsv:opencsv:2.3'
-        //not sure why I need this, but the resolution step could not find it
-        test 'org.springframework:spring-test:3.2.5.RELEASE'
     }
 
     plugins {

--- a/metridoc-grails-rid/grails-app/conf/BuildConfig.groovy
+++ b/metridoc-grails-rid/grails-app/conf/BuildConfig.groovy
@@ -63,17 +63,14 @@ grails.project.dependency.resolution = {
             excludes 'poi'
             excludes 'dom4j'
         }
-        test 'org.springframework:spring-test:3.2.5.RELEASE'
     }
 
     plugins {
         compile ":google-visualization:0.6.2"
         build(":tomcat:$grailsVersion")
-        build(":release:2.2.1", ":bintray-upload:0.2")
         build(":codenarc:0.18") {
             excludes "log4j", "groovy-all", "ant", "junit"
         }
-        build(':squeaky-clean:0.2')
         if (!useInlinePlugin) {
             compile ":metridoc-core:${coreVersion}"
         }


### PR DESCRIPTION
before we had to include spring-test as a dependency in all the
plugins.  It turned out that the mail plugin depends on spring-test
during runtime and needed to be excluded to ensure everything works.
#127
