### PR TITLE
reduce unique column sizes

### DIFF
--- a/metridoc-grails-rid/grails-app/domain/metridoc/rid/RidAudience.groovy
+++ b/metridoc-grails-rid/grails-app/domain/metridoc/rid/RidAudience.groovy
@@ -27,7 +27,7 @@ class RidAudience {
     }
 
     static constraints = {
-        name(blank: false, nullable: false, unique: true)
+        name(blank: false, nullable: false, unique: true, maxSize: 150)
         inForm(nullable: false, inList: [0, 1, 2])
         ridInsTransaction(nullable: true)
     }

--- a/metridoc-grails-rid/grails-app/domain/metridoc/rid/RidCourseSponsor.groovy
+++ b/metridoc-grails-rid/grails-app/domain/metridoc/rid/RidCourseSponsor.groovy
@@ -27,7 +27,7 @@ class RidCourseSponsor {
     }
 
     static constraints = {
-        name(blank: false, nullable: false, unique: true)
+        name(blank: false, nullable: false, unique: true, maxSize: 150)
         inForm(nullable: false, inList: [0, 1, 2])
         ridConsTransaction(nullable: true)
     }

--- a/metridoc-grails-rid/grails-app/domain/metridoc/rid/RidDepartment.groovy
+++ b/metridoc-grails-rid/grails-app/domain/metridoc/rid/RidDepartment.groovy
@@ -27,7 +27,7 @@ class RidDepartment {
     }
 
     static constraints = {
-        name(blank: false, nullable: false, unique: true)
+        name(blank: false, nullable: false, unique: true, maxSize: 150)
         fullName(blank: true, nullable: true)
         ridConsTransaction(nullable: true)
         ridInsTransaction(nullable: true)

--- a/metridoc-grails-rid/grails-app/domain/metridoc/rid/RidInstructionalMaterials.groovy
+++ b/metridoc-grails-rid/grails-app/domain/metridoc/rid/RidInstructionalMaterials.groovy
@@ -27,7 +27,7 @@ class RidInstructionalMaterials {
     }
 
     static constraints = {
-        name(blank: false, nullable: false, unique: true)
+        name(blank: false, nullable: false, unique: true, maxSize: 150)
         inForm(nullable: false, inList: [0, 1, 2])
         ridInsTransaction(nullable: true)
     }

--- a/metridoc-grails-rid/grails-app/domain/metridoc/rid/RidLibraryUnit.groovy
+++ b/metridoc-grails-rid/grails-app/domain/metridoc/rid/RidLibraryUnit.groovy
@@ -31,6 +31,6 @@ class RidLibraryUnit {
     }
 
     static constraints = {
-        name(blank: false, nullable: false, unique: true)
+        name(blank: false, nullable: false, unique: true, maxSize: 150)
     }
 }

--- a/metridoc-grails-rid/grails-app/domain/metridoc/rid/RidLocation.groovy
+++ b/metridoc-grails-rid/grails-app/domain/metridoc/rid/RidLocation.groovy
@@ -27,7 +27,7 @@ class RidLocation {
     }
 
     static constraints = {
-        name(blank: false, nullable: false, unique: true)
+        name(blank: false, nullable: false, unique: true, maxSize: 150)
         inForm(nullable: false, inList: [0, 1, 2])
         ridInsTransaction(nullable: true)
     }

--- a/metridoc-grails-rid/grails-app/domain/metridoc/rid/RidRank.groovy
+++ b/metridoc-grails-rid/grails-app/domain/metridoc/rid/RidRank.groovy
@@ -28,7 +28,7 @@ class RidRank {
     }
 
     static constraints = {
-        name(blank: false, nullable: false, unique: true)
+        name(blank: false, nullable: false, unique: true, maxSize: 150)
         inForm(nullable: false, inList: [0, 1, 2])
         ridConsTransaction(nullable: true)
         ridInsTransaction(nullable: true)

--- a/metridoc-grails-rid/grails-app/domain/metridoc/rid/RidSchool.groovy
+++ b/metridoc-grails-rid/grails-app/domain/metridoc/rid/RidSchool.groovy
@@ -28,7 +28,7 @@ class RidSchool {
     }
 
     static constraints = {
-        name(blank: false, nullable: false, unique: true)
+        name(blank: false, nullable: false, unique: true, maxSize: 150)
         inForm(nullable: false, inList: [0, 1, 2])
         ridConsTransaction(nullable: true)
         ridInsTransaction(nullable: true)


### PR DESCRIPTION
when using mysql, we should be using utf-8 which requires columns to
be smaller than the default when applying uniqueness.  I made sure
all current data in production will not cause problems with the new
constraints.
