### PR TITLE
Re-activate instructional functionality.

### DIFF
--- a/metridoc-grails-rid/grails-app/views/ridTransaction/_form.gsp
+++ b/metridoc-grails-rid/grails-app/views/ridTransaction/_form.gsp
@@ -21,10 +21,5 @@
     <tmpl:formCons/>
 </g:if>
 <g:else>
-    <g:if env="development">
-        <tmpl:formIns/>
-    </g:if>
-    <g:else>
-        Not implemented
-    </g:else>
+    <tmpl:formIns/>
 </g:else>

--- a/metridoc-grails-rid/grails-app/views/ridTransaction/list.gsp
+++ b/metridoc-grails-rid/grails-app/views/ridTransaction/list.gsp
@@ -113,8 +113,7 @@
         </g:if>
 
         <g:else>
-            <g:if env="development">
-                <div id="list-ridTransaction" class="content scaffold-list" role="main">
+            <div id="list-ridTransaction" class="content scaffold-list" role="main">
                     <h1>
                         <g:message code="default.list.label" args="[entityName]"/>
                         <g:if test="${ridTransactionAllList.size() > 0}">
@@ -176,10 +175,7 @@
                         </div>
                     </g:if>
                 </div>
-            </g:if>
-            <g:else>
-                Not yet Implemented
-            </g:else>
+
         </g:else>
     </div>
 </md:report>

--- a/metridoc-grails-rid/grails-app/views/ridTransaction/search.gsp
+++ b/metridoc-grails-rid/grails-app/views/ridTransaction/search.gsp
@@ -159,8 +159,7 @@
     </div>
 </g:if>
 <g:else>
-    <g:if env="development">
-        <div id="search-ridTransaction" class="content scaffold-search" role="main">
+    <div id="search-ridTransaction" class="content scaffold-search" role="main">
         <!--<h1><g:message code="RidInsTransaction Search"/></h1>-->
             <g:if test="${flash.message}">
                 <div class="message" role="status">${flash.message}</div>
@@ -322,10 +321,7 @@
                 </fieldset>
             </md:form>
         </div>
-    </g:if>
-    <g:else>
-        Not yet Implemented
-    </g:else>
+
 
 </g:else>
 </div>

--- a/metridoc-grails-rid/grails-app/views/ridTransaction/show.gsp
+++ b/metridoc-grails-rid/grails-app/views/ridTransaction/show.gsp
@@ -203,7 +203,6 @@
     </div>
 </g:if>
 <g:else>
-<g:if env="development">
 <g:set var="entityName" value="${message(code: 'ridTransaction.label', default: 'RidInsTransaction')}"/>
 <div id="show-ridTransaction" class="content scaffold-show" role="main">
 <h1><g:message code="default.show.label" args="[entityName]"/></h1>
@@ -424,10 +423,7 @@
 </md:form>
 
 </div>
-</g:if>
-<g:else>
-    Not yet Implemented
-</g:else>
+
 </g:else>
 </div>
 </md:report>


### PR DESCRIPTION
Note- there is very infrequent bug where a blank alert pops up occasionally after changing library unit, then switching from consultation to instructional. I have no idea yet on this one.
